### PR TITLE
Pin provider version to 6.7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Terraform module to manage settings of GitHub organization
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.6 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.7.5 |
 
 <!-- TFDOCS_PROVIDER_END -->
 
@@ -28,7 +28,7 @@ Terraform module to manage settings of GitHub organization
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.6 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
 
 <!-- TFDOCS_REQUIREMENTS_END -->
 

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -8,13 +8,13 @@ This example will multiple secrets for organization.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.6 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.6 |
+| <a name="provider_github"></a> [github](#provider\_github) | 6.7.5 |
 
 ## Modules
 
@@ -26,7 +26,7 @@ This example will multiple secrets for organization.
 
 | Name | Type |
 |------|------|
-| [github_repository.test](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
+| [github_repository.test](https://registry.terraform.io/providers/integrations/github/6.7.5/docs/resources/repository) | resource |
 
 ## Inputs
 

--- a/examples/secrets/versions.tf
+++ b/examples/secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 6.6"
+      version = "6.7.5"
     }
   }
 }

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -8,7 +8,7 @@ This example will multiple secrets for organization.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.6 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
 
 ## Providers
 

--- a/examples/settings/versions.tf
+++ b/examples/settings/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 6.6"
+      version = "6.7.5"
     }
   }
 }

--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -8,7 +8,7 @@ This example will multiple secrets for organization.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.6 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
 
 ## Providers
 

--- a/examples/webhooks/versions.tf
+++ b/examples/webhooks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 6.6"
+      version = "6.7.5"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 6.6"
+      version = "6.7.5"
     }
   }
 }


### PR DESCRIPTION
Due to Bugs introduced in `6.7.2` and `6.7.4` we have to pin the version.