### PR TITLE
Deprecation of secret fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Terraform module to manage settings of GitHub organization
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.7.5 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.12 |
 
 <!-- TFDOCS_PROVIDER_END -->
 
@@ -28,7 +28,7 @@ Terraform module to manage settings of GitHub organization
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.12 |
 
 <!-- TFDOCS_REQUIREMENTS_END -->
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Type:
 
 ```hcl
 map(object({
-    encrypted_value = optional(string)
-    plaintext_value = optional(string)
+    value           = optional(string)
+    value_encrypted = optional(string)
     visibility      = string # "all", "private" or "selected"
     repositories    = optional(set(string), [])
   }))
@@ -121,8 +121,8 @@ Type:
 
 ```hcl
 map(object({
-    encrypted_value = optional(string)
-    plaintext_value = optional(string)
+    value           = optional(string)
+    value_encrypted = optional(string)
     visibility      = string # "all", "private" or "selected"
     repositories    = optional(set(string), [])
   }))

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -8,13 +8,13 @@ This example will multiple secrets for organization.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.12 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_github"></a> [github](#provider\_github) | 6.7.5 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 6.12 |
 
 ## Modules
 
@@ -26,7 +26,7 @@ This example will multiple secrets for organization.
 
 | Name | Type |
 |------|------|
-| [github_repository.test](https://registry.terraform.io/providers/integrations/github/6.7.5/docs/resources/repository) | resource |
+| [github_repository.test](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
 
 ## Inputs
 

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -28,14 +28,14 @@ module "organization" {
       visibility = "all"
     },
     SOME_PLAIN_TEXT_SECRET = {
-      plaintext_value = "some_secret"
-      visibility      = "private"
+      value      = "some_secret"
+      visibility = "private"
     }
     ENCRYPTED_SECRET = {
       # Value encrypted with organization public key
       # Public key: https://docs.github.com/en/rest/reference/actions#get-an-organization-public-key
       # Ecnryption: https://docs.github.com/en/rest/reference/actions#create-or-update-an-organization-secret
-      encrypted_value = "P1wD+Byzy0JvL77qILs1gLj1wpDIDYIKGcHJbuILlTq3lNLgxDQuHXLVYknj2nx6uaeNGx3AmgsO+Nak"
+      value_encrypted = "P1wD+Byzy0JvL77qILs1gLj1wpDIDYIKGcHJbuILlTq3lNLgxDQuHXLVYknj2nx6uaeNGx3AmgsO+Nak"
       visibility      = "selected"
       repositories    = [github_repository.test.name]
     }
@@ -45,14 +45,14 @@ module "organization" {
       visibility = "all"
     },
     BOT_PLAIN_TEXT_SECRET = {
-      plaintext_value = "other_secret"
-      visibility      = "private"
+      value      = "other_secret"
+      visibility = "private"
     }
     ENCRYPTED_SECRET = {
       # Value encrypted with organization public key
       # Public key: https://docs.github.com/en/rest/reference/actions#get-an-organization-public-key
       # Ecnryption: https://docs.github.com/en/rest/reference/actions#create-or-update-an-organization-secret
-      encrypted_value = "P1wD+Byzy0JvL77qILs1gLj1wpDIDYIKGcHJbuILlTq3lNLgxDQuHXLVYknj2nx6uaeNGx3AmgsO+Nak"
+      value_encrypted = "P1wD+Byzy0JvL77qILs1gLj1wpDIDYIKGcHJbuILlTq3lNLgxDQuHXLVYknj2nx6uaeNGx3AmgsO+Nak"
       visibility      = "selected"
       repositories    = [github_repository.test.name]
     }

--- a/examples/secrets/main.tf
+++ b/examples/secrets/main.tf
@@ -25,6 +25,7 @@ module "organization" {
 
   secrets = {
     TEST_SECRET = {
+      value      = "test_secret"
       visibility = "all"
     },
     SOME_PLAIN_TEXT_SECRET = {
@@ -42,6 +43,7 @@ module "organization" {
   }
   bot_secrets = {
     TEST_SECRET = {
+      value      = "test_secret"
       visibility = "all"
     },
     BOT_PLAIN_TEXT_SECRET = {

--- a/examples/secrets/versions.tf
+++ b/examples/secrets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "6.7.5"
+      version = "~> 6.12"
     }
   }
 }

--- a/examples/settings/README.md
+++ b/examples/settings/README.md
@@ -8,7 +8,7 @@ This example will multiple secrets for organization.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.12 |
 
 ## Providers
 

--- a/examples/settings/versions.tf
+++ b/examples/settings/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "6.7.5"
+      version = "~> 6.12"
     }
   }
 }

--- a/examples/webhooks/README.md
+++ b/examples/webhooks/README.md
@@ -8,7 +8,7 @@ This example will multiple secrets for organization.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
-| <a name="requirement_github"></a> [github](#requirement\_github) | 6.7.5 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 6.12 |
 
 ## Providers
 

--- a/examples/webhooks/versions.tf
+++ b/examples/webhooks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "6.7.5"
+      version = "~> 6.12"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,8 @@ resource "github_actions_organization_secret" "this" {
 
   secret_name             = each.key
   visibility              = each.value.visibility
-  encrypted_value         = lookup(each.value, "encrypted_value", null)
-  plaintext_value         = lookup(each.value, "plaintext_value", null)
+  value                   = lookup(each.value, "plaintext_value", null)
+  value_encrypted         = lookup(each.value, "encrypted_value", null)
   selected_repository_ids = each.value.visibility == "selected" ? [for r in each.value["repositories"] : data.github_repository.managed[r].repo_id] : []
 }
 
@@ -49,8 +49,8 @@ resource "github_dependabot_organization_secret" "this" {
 
   secret_name             = each.key
   visibility              = each.value.visibility
-  encrypted_value         = lookup(each.value, "encrypted_value", null)
-  plaintext_value         = lookup(each.value, "plaintext_value", null)
+  value                   = lookup(each.value, "plaintext_value", null)
+  value_encrypted         = lookup(each.value, "encrypted_value", null)
   selected_repository_ids = each.value.visibility == "selected" ? [for r in each.value["repositories"] : data.github_repository.managed[r].repo_id] : []
 }
 

--- a/main.tf
+++ b/main.tf
@@ -49,8 +49,8 @@ resource "github_dependabot_organization_secret" "this" {
 
   secret_name             = each.key
   visibility              = each.value.visibility
-  value                   = lookup(each.value, "plaintext_value", null)
-  value_encrypted         = lookup(each.value, "encrypted_value", null)
+  value                   = lookup(each.value, "value", null)
+  value_encrypted         = lookup(each.value, "value_encrypted", null)
   selected_repository_ids = each.value.visibility == "selected" ? [for r in each.value["repositories"] : data.github_repository.managed[r].repo_id] : []
 }
 

--- a/main.tf
+++ b/main.tf
@@ -39,8 +39,8 @@ resource "github_actions_organization_secret" "this" {
 
   secret_name             = each.key
   visibility              = each.value.visibility
-  value                   = lookup(each.value, "plaintext_value", null)
-  value_encrypted         = lookup(each.value, "encrypted_value", null)
+  value                   = lookup(each.value, "value", null)
+  value_encrypted         = lookup(each.value, "value_encrypted", null)
   selected_repository_ids = each.value.visibility == "selected" ? [for r in each.value["repositories"] : data.github_repository.managed[r].repo_id] : []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -49,8 +49,8 @@ variable "settings" {
 variable "secrets" {
   description = "Global organization secrets"
   type = map(object({
-    encrypted_value = optional(string)
-    plaintext_value = optional(string)
+    value           = optional(string)
+    value_encrypted = optional(string)
     visibility      = string # "all", "private" or "selected"
     repositories    = optional(set(string), [])
   }))
@@ -60,8 +60,8 @@ variable "secrets" {
 variable "bot_secrets" {
   description = "Global dependabot secrets"
   type = map(object({
-    encrypted_value = optional(string)
-    plaintext_value = optional(string)
+    value           = optional(string)
+    value_encrypted = optional(string)
     visibility      = string # "all", "private" or "selected"
     repositories    = optional(set(string), [])
   }))

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "6.7.5"
+      version = "~> 6.12"
     }
   }
 }


### PR DESCRIPTION
Due to changes introduced in github provider `v6.12`:
- `encrypted_value` -> `value_encrypted` 
- `plaintext_value` -> `value`

Ref: https://github.com/integrations/terraform-provider-github/pull/3225