### PR TITLE
Migrate org secrets permissions to new resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,23 +37,41 @@ resource "github_organization_settings" "this" {
 resource "github_actions_organization_secret" "this" {
   for_each = var.secrets
 
-  secret_name             = each.key
-  visibility              = each.value.visibility
-  value                   = lookup(each.value, "value", null)
-  value_encrypted         = lookup(each.value, "value_encrypted", null)
-  key_id                  = lookup(each.value, "value_encrypted", null) != null ? data.github_actions_organization_public_key.this.key_id : null
-  selected_repository_ids = each.value.visibility == "selected" ? [for r in each.value["repositories"] : data.github_repository.managed[r].repo_id] : []
+  secret_name     = each.key
+  visibility      = each.value.visibility
+  value           = lookup(each.value, "value", null)
+  value_encrypted = lookup(each.value, "value_encrypted", null)
+  key_id          = lookup(each.value, "value_encrypted", null) != null ? data.github_actions_organization_public_key.this.key_id : null
+}
+
+resource "github_actions_organization_secret_repositories" "this" {
+  for_each = {
+    for name, secret in var.secrets : name => secret
+    if secret.visibility == "selected"
+  }
+
+  secret_name             = github_actions_organization_secret.this[each.key].secret_name
+  selected_repository_ids = [for r in each.value.repositories : data.github_repository.managed[r].repo_id]
 }
 
 resource "github_dependabot_organization_secret" "this" {
   for_each = var.bot_secrets
 
-  secret_name             = each.key
-  visibility              = each.value.visibility
-  value                   = lookup(each.value, "value", null)
-  value_encrypted         = lookup(each.value, "value_encrypted", null)
-  key_id                  = lookup(each.value, "value_encrypted", null) != null ? data.github_dependabot_organization_public_key.this.key_id : null
-  selected_repository_ids = each.value.visibility == "selected" ? [for r in each.value["repositories"] : data.github_repository.managed[r].repo_id] : []
+  secret_name     = each.key
+  visibility      = each.value.visibility
+  value           = lookup(each.value, "value", null)
+  value_encrypted = lookup(each.value, "value_encrypted", null)
+  key_id          = lookup(each.value, "value_encrypted", null) != null ? data.github_dependabot_organization_public_key.this.key_id : null
+}
+
+resource "github_dependabot_organization_secret_repositories" "this" {
+  for_each = {
+    for name, secret in var.bot_secrets : name => secret
+    if secret.visibility == "selected"
+  }
+
+  secret_name             = github_dependabot_organization_secret.this[each.key].secret_name
+  selected_repository_ids = [for r in each.value.repositories : data.github_repository.managed[r].repo_id]
 }
 
 resource "github_organization_webhook" "this" {


### PR DESCRIPTION
Organization secrets permissions are managed with separate resource now and `selected_repository_ids` field in `github_actions_organization_secret` and `github_dependabot_organization_secret` resources is deprecated.